### PR TITLE
Ispravljeni neki od bagova

### DIFF
--- a/api/config/plugins.ts
+++ b/api/config/plugins.ts
@@ -51,6 +51,7 @@ export default ({ env }) => ({
           items: [
             "heading1",
             "heading2",
+            "heading3",
             "|",
             "bold",
             "italic",

--- a/izadji/src/components/Newsletter/Newsletter.tsx
+++ b/izadji/src/components/Newsletter/Newsletter.tsx
@@ -1,9 +1,9 @@
 import { FieldValues, useForm } from 'react-hook-form';
 import toast from 'react-hot-toast';
-import ReactMarkdown from 'react-markdown';
 import formService from '../../services/formService';
 import Toast from '../shared/Toast/Toast';
 import styles from './Newsletter.module.scss';
+import parse from 'html-react-parser';
 
 export type NavBarButtonProps = {
   title: string;
@@ -33,7 +33,7 @@ const Newsletter = ({ title, buttonText }: NavBarButtonProps): JSX.Element => {
       <div className={styles.wrap}>
         <div className={styles.newsletter__inner}>
           <p className={`${styles.newsletter__title}`}>
-            <ReactMarkdown>{title}</ReactMarkdown>
+            <>{parse(title)}</>
           </p>
           <form
             className={`${styles.newsletter__form} ${styles.form}`}

--- a/izadji/src/components/WorkProgrammeCard/WorkProgrammeCard.tsx
+++ b/izadji/src/components/WorkProgrammeCard/WorkProgrammeCard.tsx
@@ -15,11 +15,11 @@ const WorkProgrammeCard = ({
 }: WorkProgrammeCardProps) => {
   return (
     <div className={styles.box__slider__item}>
-      <Link to={link} className={styles.box__slider__inner}>
+      <a href={link} className={styles.box__slider__inner}>
         <h3 className={styles.box__slider__heading}>{heading}</h3>
         <p className={styles.box__slider__text}>{description}</p>
         <span className={styles.box__slider__link}>Saznaj više</span>
-      </Link>
+      </a>
     </div>
   );
 };

--- a/izadji/src/services/blogNewsPageService.ts
+++ b/izadji/src/services/blogNewsPageService.ts
@@ -8,7 +8,7 @@ const getBlogs = (
   page: number
 ) =>
   axios.get(
-    `/api/blog-pages?filters[work_program][id][$eq]=${workProgrammeId}&populate=deep&pagination[page]=${page}&pagination[pageSize]=${blogsPerPage}&filters[blog_page_tags][title][$containsi]=${searchString}`
+    `/api/blog-pages?filters[work_program][id][$eq]=${workProgrammeId}&populate=deep&pagination[page]=${page}&pagination[pageSize]=${blogsPerPage}&filters[blog_page_tags][title][$contains]=${searchString}`
   );
 
 const blogNewsPageService = {


### PR DESCRIPTION
1. Ne mogu da stavim H3 u Rich text component (ili bilo koji Heading koji nije H1 ili H2). Da li ja ne znam da odaberem drugi heading ili ne postoji mogucnost?
	- izmena je dodata u plugins.ts fajl, ali pitanje je koliko heading-a zelimo da omogucimo i da li moze da se doda u 
	  options vise od 4.
2. Kada iz sekcije "Ostali programi rada", kliknem na neki program rada, on samo promeni stranicu (tj. work-program-id iz path-a u url-u), ali ne ode na vrh novoodabrane stranice, nego na njenu komponentu "Ostali programi rada".
	- work program card - nije Link nego a tag.
3. Tekst u Newsletter komponenti se ne prikazuje lepo, nego u ovoj formi: "<p>Prijavi se na <strong>newsletter</strong> i saznaj sve na vreme, budi uvek u toku!</p>" na stranici work-program. Lepo se vidi u editoru u Content Manager-u, ali na FE aplikaciji ne.
	- dodat parser za Newsletter komponentu.
4. Kombinacija search-a i pretrage nije radila dobro zbog slovne gresko u zahtevu koji se slao na Strapi.